### PR TITLE
Patch 1

### DIFF
--- a/avl/src/main/java/org/example/Main.java
+++ b/avl/src/main/java/org/example/Main.java
@@ -151,6 +151,7 @@ class SøkeBinærTre<T> implements Beholder<T> {
                     }
                 }
                 nyRot.forelder = node.forelder;
+                nyRot.venstre.forelder = nyRot;
                 node.forelder = nyRot;
                 node = nyRot;
             }
@@ -168,6 +169,7 @@ class SøkeBinærTre<T> implements Beholder<T> {
                     }
                 }
                 nyRot.forelder = node.forelder;
+                nyRot.høyre.forelder = nyRot;
                 node.forelder = nyRot;
                 node = nyRot;
             }

--- a/avl/src/main/java/org/example/Main.java
+++ b/avl/src/main/java/org/example/Main.java
@@ -117,6 +117,7 @@ class SøkeBinærTre<T> implements Beholder<T> {
                     }
                 }
                 nyRot.forelder = node.forelder; // oppdater forelderen til nyRot
+                node.forelder = nyRot; // oppdater forelder til node
                 node = nyRot;
             }
             // Høyre høyre tilfelle
@@ -132,6 +133,7 @@ class SøkeBinærTre<T> implements Beholder<T> {
                     }
                 }
                 nyRot.forelder = node.forelder;
+                node.forelder = nyRot;
                 node = nyRot;
             }
             // Venstre høyre tilfelle
@@ -149,6 +151,7 @@ class SøkeBinærTre<T> implements Beholder<T> {
                     }
                 }
                 nyRot.forelder = node.forelder;
+                node.forelder = nyRot;
                 node = nyRot;
             }
             // Høyre venstre tilfelle
@@ -165,6 +168,7 @@ class SøkeBinærTre<T> implements Beholder<T> {
                     }
                 }
                 nyRot.forelder = node.forelder;
+                node.forelder = nyRot;
                 node = nyRot;
             }
             node = node.forelder;


### PR DESCRIPTION
foreldrepekerne til gamle noden ble ikke oppdatert når man gjorde rotasjoner, så noen noder fikk feil foreldrepekere.

Bedre løsning:
Fiks foreldrepekere i venstrerotasjon og høyrerotasjon-funksjonene.